### PR TITLE
INGEST-3258: Changed the end livestream endpoint

### DIFF
--- a/src/resources/Livestreams.js
+++ b/src/resources/Livestreams.js
@@ -17,9 +17,7 @@ function Livestreams (options) {
   var overrides = {
     resource: ResourceTypes.LIVESTREAMS,
     status: '/<%=resource%>/<%=id%>/status',
-    deleteMethods: {
-      'end': '?end=1'
-    }
+    end: '/<%=resource%>/<%=id%>/stop'
   };
 
   options = extend(true, {}, overrides, options);
@@ -93,34 +91,35 @@ Livestreams.prototype.getStatus = function (id) {
 };
 
 /**
- * Delete/End a single livestream
+ * Ends a livestream
  *
- * @param  {string}  id  - Livestream id.
- * @param  {boolean} end - A flag to end the stream instead of remove it
+ * @param {string} id        - The id of the livestream to end
+ * @param {string} streamKey - The streamKey for the livestream you wish to end
  *
  * @return {promise} A promise which resolves when the request is complete.
  */
-Livestreams.prototype.delete = function (id, end) {
-  var request, url;
+Livestreams.prototype.end = function (id, streamKey) {
+  var request, url, data;
 
-  if (typeof id !== 'string') {
+  if (typeof id !== 'string' || typeof streamKey !== 'string') {
     return utils.promisify(false,
-      'IngestSDK Livestream.delete requires a valid id passed as a string.');
+      'IngestSDK Livestream.end requires a valid id and stream key passed as a string.');
   }
 
-  url = utils.parseTokens(this.config.host + this.config.byId, {
+  url = utils.parseTokens(this.config.host + this.config.end, {
     resource: this.config.resource,
     id: id
   });
 
-  if (end === true) {
-    url += this.config.deleteMethods.end;
+  data = {
+    stream_key: streamKey
   }
 
   request = new Request({
     url: url,
     token: this._tokenSource(),
-    method: 'DELETE'
+    method: 'POST',
+    data: data
   });
 
   return request.send();

--- a/tests/resources/Livestreams.spec.js
+++ b/tests/resources/Livestreams.spec.js
@@ -160,70 +160,32 @@ describe('Ingest API : Resource : Livestreams', function () {
     });
   });
 
-  describe('delete', function () {
+  describe('end', function () {
 
-    it('Should delete a livestream.', function (done) {
+    it('Should end a livestream.', function (done) {
       var request, url;
 
       // Mock the XHR object
       mock.setup();
 
       // Mock the response from the REST api.
-      mock.mock('DELETE', api.config.host + '/live/live-id',
+      mock.mock('POST', api.config.host + '/live/live-id/stop',
         function (request, response) {
-
-          var data = {
-            ok: true
-          };
 
           // Restore the XHR object.
           mock.teardown();
 
           return response.status(200)
             .header('Content-Type', 'application/json')
-            .body(JSON.stringify(data));
+            .body(JSON.stringify({}));
 
         });
 
-      request = livestreamResource.delete('live-id').then(function (response) {
+      request = livestreamResource.end('live-id', 'streamkey').then(function (response) {
         expect(response).toBeDefined();
-        expect(response.data).toBeDefined();
-        done();
-      }, function (error) {
-        expect(error).toBeUndefined();
-        done();
-      });
-
-      // Ensure a promise was returned.
-      expect(request.then).toBeDefined();
-    });
-
-    it('Should end a livestream.', function (done) {
-      var request;
-
-      // Mock the XHR object
-      mock.setup();
-
-      // Mock the response from the REST api.
-      mock.mock('DELETE', api.config.host + '/live/live-id?end=1',
-        function (request, response) {
-
-          var data = {
-            ok: true
-          };
-
-          // Restore the XHR object.
-          mock.teardown();
-
-          return response.status(200)
-            .header('Content-Type', 'application/json')
-            .body(JSON.stringify(data));
-
-        });
-
-      request = livestreamResource.delete('live-id', true).then(function (response) {
-        expect(response).toBeDefined();
-        expect(response.data).toBeDefined();
+        expect(response.headers).toBeDefined();
+        expect(typeof response.headers).toBe('function');
+        expect(response.statusCode).toBeDefined();
         done();
       }, function (error) {
         expect(error).toBeUndefined();
@@ -235,8 +197,25 @@ describe('Ingest API : Resource : Livestreams', function () {
     });
 
     it('Should fail if the id is not a string', function (done) {
+      var request = livestreamResource.end({test: true}).then(function (response) {
+        expect(response).not.toBeDefined();
 
-      var request = livestreamResource.delete({test: true}).then(function (response) {
+        done();
+
+      }, function (error) {
+
+        expect(error).toBeDefined();
+
+        done();
+
+      });
+
+      // Ensure a promise was returned.
+      expect(request.then).toBeDefined();
+    });
+
+    it('Should fail if the streamkey is not a string', function (done) {
+      var request = livestreamResource.end('id', {test: true}).then(function (response) {
         expect(response).not.toBeDefined();
 
         done();


### PR DESCRIPTION
Due to the new On Demand Transcoder support we needed to change the end livestream endpoint.

The delete and permanent delete endpoints now pull from the base class instead.